### PR TITLE
Made the application_id optional for the /cities endpoint

### DIFF
--- a/app/routers/cities_router.py
+++ b/app/routers/cities_router.py
@@ -30,8 +30,12 @@ router = APIRouter()
 
 
 @router.get(
-    "/{application_id}",
-    dependencies=[Depends(validate_query_params("projects", "country_code_iso3"))],
+    "",
+    dependencies=[
+        Depends(
+            validate_query_params("projects", "country_code_iso3", "application_id")
+        )
+    ],
     responses={
         200: {**COMMON_200_SUCCESSFUL_RESPONSE, "model": CityList},
         400: COMMON_400_ERROR_RESPONSE,
@@ -39,7 +43,7 @@ router = APIRouter()
     },
 )
 def list_cities(
-    application_id: str = Path(),
+    application_id: Optional[str] = Query(None),
     projects: Optional[List[str]] = Query(None),
     country_code_iso3: Optional[str] = Query(None),
 ):
@@ -47,6 +51,7 @@ def list_cities(
     Retrieve a list of cities filtered by project IDs and/or country code.
 
     ### Args:
+    - **application_id** (`Optional[str]`): A WRI cities application ID used to filter the cities.
     - **projects** (`Optional[List[str]]`): A list of Project IDs used to filter the cities.
     - **country_code_iso3** (`Optional[str]`): An ISO 3166-1 alpha-3 country code used to filter the cities.
 

--- a/app/services/cities_service.py
+++ b/app/services/cities_service.py
@@ -22,20 +22,25 @@ set_default_credentials(
 
 
 def list_cities(
-    application_id: str, projects: Optional[List[str]], country_code_iso3: Optional[str]
+    application_id: Optional[str],
+    projects: Optional[List[str]],
+    country_code_iso3: Optional[str],
 ) -> List[Dict[str, Any]]:
     """
     Retrieve a list of cities based on the provided filters.
 
     Args:
+        application_id (Optional[str]): A WRI application ID to filter by.
         projects (Optional[List[str]]): List of Project IDs to filter by.
         country_code_iso3 (Optional[str]): ISO 3166-1 alpha-3 country code to filter by.
 
     Returns:
         List[Dict[str, Any]]: A list of dictionaries containing the filtered cities' data.
     """
-    # Fetch projects based on provided project IDs if provided
-    projects_filters: Dict[str, str | List[str]] = {"application_id": application_id}
+    # Fetch projects based on provided project IDs/application ID if provided
+    projects_filters = {}
+    if application_id:
+        projects_filters["application_id"] = application_id
     if projects:
         projects_filters["id"] = projects
     projects_filter_formula = construct_filter_formula(projects_filters)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x ] Check the commit's or even all commits' message styles matches our requested structure.
- [x ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Because two endpoints (/cities/{applicatop_id} and /cities/{city_id}) have the same endpoint pattern, the second was never getting invoked.

Issue Number: CCL-161


## What is the new behavior?
Made the application_id optional in the /cities enpoint

-
-
-

## Does this introduce a breaking change?

- [x ] Yes
- [ ] No

Need to change the front end to pass the right URL


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
