### PR TITLE
Modified the layer_url content to add the sub directory depending on the layer type

### DIFF
--- a/app/services/layers_service.py
+++ b/app/services/layers_service.py
@@ -29,7 +29,6 @@ def generate_layer_response(
             f"{'-' + layer_fields['version'] if 'version' in layer_fields else ''}"
             f".{layer_fields.get('file_type')}"
         )
-    layer_url = urljoin(s3_path, layer_file_name)
 
     try:
         map_styling = json.loads(layer_fields.get("map_styling", "{}"))
@@ -47,12 +46,21 @@ def generate_layer_response(
         "legend_styling": legend_styling,
     }
     if layer_fields.get("layer_type") == "vector":
+        geojson_sub_url = urljoin(s3_path, "geojson/")
+        geojson_layer_url = urljoin(geojson_sub_url, layer_file_name)
+        pmtiles_sub_url = urljoin(s3_path, "pmtiles/")
+        pmtiles_layer_url = (
+            f"{os.path.splitext(urljoin(pmtiles_sub_url, layer_file_name))[0]}.pmtiles"
+        )
         return_dict["layers_url"] = {
-            "geojson": layer_url,
-            "pmtiles": f"{os.path.splitext(layer_url)[0]}.pmtiles",
+            "geojson": geojson_layer_url,
+            "pmtiles": pmtiles_layer_url,
         }
     else:
-        return_dict["layers_url"] = {"cog": layer_url}
+        cog_sub_url = urljoin(s3_path, "cog/")
+        cog_layer_url = urljoin(cog_sub_url, layer_file_name)
+        return_dict["layers_url"] = {"cog": cog_layer_url}
+
     return return_dict
 
 


### PR DESCRIPTION
…the layer type

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ x] Check the commit's or even all commits' message styles matches our requested structure.
- [ x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently the airtable can only store one directory but for vector urls, we need two types

Issue Number: CCL-230


## What is the new behavior?
Generates the subdirs based on the layer type

-
-
-

## Does this introduce a breaking change?

- [ x] Yes
- [ ] No

Airtable needs changes in s3_path to accomodate this


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
